### PR TITLE
TV Maze Marked As Watched Support

### DIFF
--- a/script.media.maintenance/addon.xml
+++ b/script.media.maintenance/addon.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="script.media.maintenance" version="1.0.9" name="Media Maintenance" provider-name="Lunatixz">
+<addon id="script.media.maintenance" version="1.0.10~beta1" name="Media Maintenance" provider-name="Lunatixz">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.schedule" version="0.5.0"/>
         <import addon="script.module.simplecache" version="1.0.0"/>
+		<import addon="script.module.requests" version="2.22.0" />
     </requires>
     <extension point="xbmc.python.script" library="default.py"/>
     <extension point="xbmc.service" library="service.py" start="login"/>

--- a/script.media.maintenance/default.py
+++ b/script.media.maintenance/default.py
@@ -19,7 +19,7 @@
 # -*- coding: utf-8 -*-
 import os, sys, time, datetime, re, traceback
 import urlparse, urllib, urllib2, socket, json, collections
-import xbmc, xbmcgui, xbmcplugin, xbmcaddon, xbmcvfs
+import xbmc, xbmcgui, xbmcplugin, xbmcaddon, xbmcvfs, tvmaze
 from simplecache import SimpleCache, use_cache
 
 # Plugin Info
@@ -198,6 +198,7 @@ class MM(object):
                 tvshow   = playingItem["showtitle"]
                 userList = self.getUserList()
                 if tvshow not in userList and not bypass: return
+                self.markWatchedTVMaze( tvshow, playingItem["season"], playingItem["episode"] )
                 mediaInfo = '%s - %sx%s - %s'%(tvshow,playingItem["season"],playingItem["episode"],mediaInfo)
             if silent == False:
                 if not self.yesnoDialog(mediaInfo, file, header='%s - %s'%(ADDON_NAME,LANGUAGE(30021)%(type)), yes='Remove', no='Keep', autoclose=15000): return
@@ -217,6 +218,51 @@ class MM(object):
             log('removeContent, playingItem = ' + json.dumps(playingItem))
         
         
+    def markWatchedTVMaze ( self, show, season, episode ):
+        TVMAZE = tvmaze.API( user=REAL_SETTINGS.getSetting('TVMaze_User'), apikey=REAL_SETTINGS.getSetting('TVMaze_APIKey') )
+        show_info = {'name':show, 'season':season, 'episode':episode}
+        success, loglines, results = TVMAZE.getFollowedShows( params={'embed':'show'} )
+        if not success:
+            log( 'bad response from TV Maze, no shows returned - aborting' )
+            return
+        tvmazeid = ''
+        so_file = os.path.join( SETTINGS_LOC, 'show_override.json' )
+        if xbmcvfs.exists( so_file ):
+            thefile = xbmcvfs.File( so_file, 'r' )
+            thedata = thefile.read()
+            thefile.close()
+            show_override = json.loads( thedata )
+        else:
+            show_override = {}
+        log( 'checking to see if there is an override for %s' % show_info['name'] )
+        try:
+            show_info['name'] = show_override[show_info['name']]
+        except KeyError:
+            log( 'no show override found, using original' )
+        log( 'using show name of %s' % show_info['name'] )
+        for followed_show in results:
+            try:
+                followed_name = followed_show['_embedded']['show']['name']
+            except KeyError:
+                continue
+            if followed_name == show_info['name']:
+                log( 'found match for %s' % show_info['name'] )
+                tvmazeid = followed_show['show_id']
+                break
+        if tvmazeid:
+            params = {'season':show_info['season'], 'number':show_info['episode']}
+            success, loglines, results = TVMAZE.getEpisodeBySeasonEpNumber( tvmazeid, params )
+            try:
+                episodeid = results['id']
+            except KeyError:
+                episodeid = ''
+            if episodeid:
+                log( 'got episode id of %s' % episodeid )
+                success, loglines, results = TVMAZE.markEpisode( episodeid )
+                if not success:
+                    log( 'bad response from TV Maze, show was not marked' )
+
+
     def deleteFile(self, file):
         log("deleteFile")
         for i in range(3):

--- a/script.media.maintenance/default.py
+++ b/script.media.maintenance/default.py
@@ -125,10 +125,10 @@ class MM(object):
     def getUserList(self, type='series'):
         REAL_SETTINGS = xbmcaddon.Addon(id=ADDON_ID)
         if type == 'series': 
-            try: return (REAL_SETTINGS.getSetting('TVShowList').split(',') or [])
+            try: return (REAL_SETTINGS.getSetting('TVShowList').split(':&:') or [])
             except: return []
         else:
-            try: return (REAL_SETTINGS.getSetting('MoviesList').split(',') or [])
+            try: return (REAL_SETTINGS.getSetting('MoviesList').split(':&:') or [])
             except: return []
         
         
@@ -149,7 +149,7 @@ class MM(object):
         else: 
             self.notificationDialog(LANGUAGE(30017))
             REAL_SETTINGS.setSetting(setSetting0,'')
-        userList = ','.join(list(set(userList)))
+        userList = ':&:'.join(list(set(userList)))
         log('setUserList, UserList = ' + userList + ', type = ' + type)
         REAL_SETTINGS.setSetting(setSetting1,userList)
         REAL_SETTINGS.setSetting(setSetting2,msg)

--- a/script.media.maintenance/resources/language/resource.language.en_gb/strings.po
+++ b/script.media.maintenance/resources/language/resource.language.en_gb/strings.po
@@ -203,3 +203,15 @@ msgstr ""
 msgctxt "#30046"
 msgid "General"
 msgstr ""
+
+msgctxt "#30047"
+msgid "TV Maze Username"
+msgstr ""
+
+msgctxt "#30048"
+msgid "TV Maze API Key"
+msgstr ""
+
+msgctxt "#30049"
+msgid "TV Maze"
+msgstr ""

--- a/script.media.maintenance/resources/settings.xml
+++ b/script.media.maintenance/resources/settings.xml
@@ -29,6 +29,10 @@
     <setting label="30019"         type="lsep" />
     <setting id="Radarr_IP"        type="text"   label="30007"  subsetting="true" default="http://localhost:7878" />
     <setting id="Radarr_API"       type="text"   label="30008"  subsetting="true" default="" />
+    <setting label="30049"         type="lsep" />
+    <setting id="TVMaze_User"      type="text"   label="30047"  subsetting="true" default="" />
+    <setting id="TVMaze_APIKey"    type="text"   label="30048"  subsetting="true" default="" />
+    
     <setting id="MoviesList"       type="text"   label="30005"  enable="false"    visible="false"       default="" />
     </category>
 </settings>

--- a/script.media.maintenance/tvmaze.py
+++ b/script.media.maintenance/tvmaze.py
@@ -1,0 +1,79 @@
+#v.0.3.2
+
+import json, url
+
+headers = {}
+headers['Content-Type'] = 'application/json'
+headers['Accept'] = 'application/json'
+JSONURL = url.URL( 'json', headers=headers )
+TXTURL = url.URL()
+
+
+class API( object ):
+
+    def __init__( self, user='', apikey='' ):
+        self.PUBLICURL = 'https://api.tvmaze.com'
+        self.USER = user
+        self.APIKEY = apikey
+        if user and apikey:
+            self.AUTHURL = 'https://api.tvmaze.com/v1/user'
+        else:
+            self.AUTHURL = self.PUBLICURL
+
+
+    def getShow( self, tvmazeid, params=None ):
+        return self._call( 'shows/%s' % tvmazeid, params )
+
+
+    def getEpisode( self, episodeid, params=None ):
+        return self._call( 'episodes/%s' % episodeid, params )
+
+
+    def getEpisodeBySeasonEpNumber( self, tvmazeid, params ):
+        return self._call( 'shows/%s/episodebynumber' % tvmazeid, params )
+
+
+    def getFollowedShows( self, params=None ):
+        return self._call( 'follows/shows', params, auth=True )
+
+
+    def getTaggedShows( self, tag, params=None ):
+        return self._call( 'tags/%s/shows' % tag, params, auth=True )
+
+
+    def markEpisode( self, episodeid, marked_as=0, marked_at=0, params=None ):
+        payload = {'episode_id':0, 'type':marked_as, 'marked_at':marked_at }
+        return self._call( 'episodes/%s' % episodeid, params, data=json.dumps( payload ), type='put', auth=True )
+        
+
+    def unTagShow( self, show, tag, params=None ):
+        return self._call( 'tags/%s/shows/%s' % (tag, show), params, auth=True, type='delete' )
+
+
+    def getTags( self, params=None ):
+        return self._call( 'tags', params, auth=True )
+
+
+    def _call( self, url_end, params, data=None, auth=False, type="get" ):
+        loglines = []
+        if not params:
+            params = {}
+        if not data:
+            data = {}
+        if auth:
+            if self.AUTHURL == self.PUBLICURL:
+                loglines.append( 'authorization credentials required but not supplied' )
+                return False, loglines, {}
+            url_base = self.AUTHURL
+            auth = (self.USER, self.APIKEY)
+        else:
+            url_base = self.PUBLICURL
+        theurl = '%s/%s' % (url_base, url_end )
+        if type == 'get':
+            status, j_loglines, results = JSONURL.Get( theurl, auth=auth, params=params )
+        if type == 'put':
+            status, j_loglines, results = JSONURL.Put( theurl, auth=auth, params=params, data=data )
+        if type == 'delete':
+            status, j_loglines, results = TXTURL.Delete( theurl, auth=auth, params=params )
+        loglines.extend( j_loglines )
+        return status == 200, loglines, results

--- a/script.media.maintenance/url.py
+++ b/script.media.maintenance/url.py
@@ -1,0 +1,107 @@
+#v.0.5.1
+
+import socket
+import requests as _requests
+
+class URL( object ):
+
+    def __init__( self, returntype='text', headers='', timeout=10 ):
+        self.TIMEOUT = timeout
+        self.HEADERS = headers
+        self.RETURNTYPE = returntype
+
+
+    def Get( self, theurl, **kwargs ):
+        return self._urlcall( theurl, 'get', kwargs )
+
+
+    def Post( self, theurl, **kwargs ):
+        return self._urlcall( theurl, 'post', kwargs )
+
+
+    def Put( self, theurl, **kwargs ):
+        return self._urlcall( theurl, 'put', kwargs )
+
+
+    def Delete( self, theurl, **kwargs ):
+        return self._urlcall( theurl, 'delete', kwargs )
+
+
+    def _urlcall( self, theurl, urltype, kwargs ):
+        loglines = []
+        urldata = ''
+        bad_r = False
+        auth, params, thedata = self._unpack_args( kwargs )
+        try:
+            if urltype == "get":
+                urldata = _requests.get( theurl, auth=auth, params=params, headers=self.HEADERS, timeout=self.TIMEOUT )
+            elif urltype == "post":
+                urldata = _requests.post( theurl, auth=auth, params=params, data=thedata, headers=self.HEADERS, timeout=self.TIMEOUT )
+            elif urltype == "put":
+                urldata = _requests.put( theurl, auth=auth, params=params, data=thedata, headers=self.HEADERS, timeout=self.TIMEOUT )
+            elif urltype == "delete":
+                urldata = _requests.delete( theurl, auth=auth, params=params, data=thedata, headers=self.HEADERS, timeout=self.TIMEOUT )
+            loglines.append( "the url is: " + urldata.url )
+            loglines.append( 'the params are: ')
+            loglines.append( params )
+            loglines.append( 'the data are: ')
+            loglines.append( thedata )
+            urldata.raise_for_status()
+        except _requests.exceptions.ConnectionError as e:
+            loglines.append( 'site unreachable at ' + theurl )
+            loglines.append( e )
+            bad_r = True
+        except _requests.exceptions.Timeout as e:
+            loglines.append( 'timeout error while downloading from ' + theurl )
+            loglines.append( e )
+            bad_r = True
+        except socket.timeout as e:
+            loglines.append( 'timeout error while downloading from ' + theurl )
+            loglines.append( e )
+            bad_r = True
+        except _requests.exceptions.HTTPError as e:
+            loglines.append( 'HTTP Error while downloading from ' + theurl )
+            loglines.append( e )
+            bad_r = True
+        except _requests.exceptions.RequestException as e:
+            loglines.append( 'unknown error while downloading from ' + theurl )
+            loglines.append( e )
+            bad_r = True
+        if bad_r:
+            return False, loglines, ''
+        if urldata:
+            success = True
+            loglines.append( 'returning URL as ' + self.RETURNTYPE )
+            if self.RETURNTYPE == 'text':
+                data = urldata.text
+            elif self.RETURNTYPE == 'binary':
+                data = urldata.content
+            elif self.RETURNTYPE == 'json':
+                data = urldata.json()
+            else:
+                loglines.append( 'unable to convert returned object to acceptable type' )
+                return False, loglines, ''
+        else:
+            return False, loglines, ''
+        loglines.append( '-----URL OBJECT RETURNED-----' )
+        loglines.append( data )
+        return urldata.status_code, loglines, data
+
+
+    def _unpack_args( self, kwargs ):
+        try:
+            auth = kwargs['auth']
+        except KeyError:
+            auth = ()
+        try:
+            params = kwargs['params']
+        except KeyError:
+            params = {}
+        try:
+            thedata = kwargs['data']
+        except KeyError:
+            if self.RETURNTYPE == 'json':
+                thedata = []
+            else:
+                data = ''
+        return auth, params, thedata


### PR DESCRIPTION
There are two commits in this PR.  The first one is the fix I mentioned in the Kodi forums for shows that have commas in their name.

A bit about the other commit.  TV Maze has a python binding, but it is incomplete and didn't include the function to mark shows as watched.  The instructions also said to install it via pip, so including it would have meant doing it from their github anyway.  So I did a partial build of a new API that has the functions I need for my various projects.  It does use a wrapper I wrote for Requests, so the commit is a little heavy in terms of lines of code for the functionality.  Up to you if it makes sense to keep all that or maybe use some other url integration you like.  My wrapper is Python2/3 compliant, so there is that at least.