### PR TITLE
Update plutotv.py

### DIFF
--- a/plugin.video.plutotv/resources/lib/plutotv.py
+++ b/plugin.video.plutotv/resources/lib/plutotv.py
@@ -397,7 +397,7 @@ class PlutoTV(object):
 
                 tmpdata = {"mediatype":mtype,"label":label,"title":label,'duration':epdur,'plot':epplot,'genre':[epgenre],'season':epseason,'episode':epnumber}
                 tmpdata['starttime'] = time.mktime((start).timetuple())
-                tmpdata['url'] = self.sysARG[0]+'?mode=9&name=%s&url=%s'%(title,urls)
+                tmpdata['url'] = self.sysARG[0]+'?mode=9&name=%s&url=%s'%(title,urllib.parse.quote(urls))
                 tmpdata['art'] = {"thumb":thumb,"poster":epposter,"fanart":epfanart,"icon":chlogo,"logo":chlogo,"clearart":chthumb}
                 guidedata.append(tmpdata)
                 


### PR DESCRIPTION
Wrapping url for guidedata using the quote method from urllib.parse to allow uEPG to property pass stream URL to plutotv.py.