### PR TITLE
A couple of fixes for HDTC-2UC transcode devices

### DIFF
--- a/plugin.video.hdhomerun.simple/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.hdhomerun.simple/resources/language/resource.language.en_gb/strings.po
@@ -32,6 +32,10 @@ msgctxt "#30101"
 msgid "Available Devices"
 msgstr ""
 
+msgctxt "#30102"
+msgid "General"
+msgstr ""
+
 msgctxt "#30103"
 msgid "Tuner Details"
 msgstr ""
@@ -154,8 +158,4 @@ msgstr ""
 
 msgctxt "#49012"
 msgid "Favorites"
-msgstr ""
-
-msgctxt "#30101"
-msgid "General"
 msgstr ""

--- a/plugin.video.hdhomerun.simple/resources/lib/hdhomerun.py
+++ b/plugin.video.hdhomerun.simple/resources/lib/hdhomerun.py
@@ -523,7 +523,7 @@ class HDHR(object):
         url   = info.getURL()
         tuner = info.getTuner()
         if tuner.getModelNumber() == "HDTC-2US":
-            if self.transcode == 'none': tranOPT = (tuner.getTranscodeOption() or 'none')
+            if self.transcode == 'default': tranOPT = (tuner.getTranscodeOption() or 'none')
             else: tranOPT = self.transcode
             log("resolveURL, Tuner transcode option: " + tranOPT)
             if tranOPT != "none": video = {'codec': 'h264'}

--- a/script.module.pyhdhr/lib/pyhdhr/PyHDHR.py
+++ b/script.module.pyhdhr/lib/pyhdhr/PyHDHR.py
@@ -583,7 +583,7 @@ class Tuner(BaseDevice):
         if self.ModelNumber == "HDTC-2US":
             try:
                 response = urllib.request.urlopen(self.BaseURL+"/transcode.html",None,5)
-                regx = re.compile('transcodeChanged\(\)">((.|\n)+?)</select>', re.IGNORECASE).search(response.read())
+                regx = re.compile('transcodeChanged\(\)">((.|\n)+?)</select>', re.IGNORECASE).search(response.read().decode('utf-8'))
                 selecttags = regx.group(1)
                 
                 regx = re.compile('.+"(.*)".+selected=', re.IGNORECASE).search(selecttags)


### PR DESCRIPTION
A couple of fixes for HDTC-2UC transcode devices
1) PyHDHR.py throws an exception exception because response.read() returns 'bytes' and the re.complie was expecting a string.
2) hdhomerun.py tries to connect to an invalid URL i.e. one with ?transcode=default
3) I also noticed that a label was missing in the hdhomerun simple configuration page so I fixed that as well.

sorry for the 2nd PR - I messed up my git command on my end.