### PR TITLE
[plugin.video.xumotv] fix strings.po

### DIFF
--- a/plugin.video.xumotv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.xumotv/resources/language/resource.language.en_gb/strings.po
@@ -46,8 +46,8 @@ msgstr ""
 
 msgctxt "#30007"
 msgid "All Channels"
-msgstr "
+msgstr ""
 
 msgctxt "#30008"
 msgid ">> Next"
-msgstr "
+msgstr ""


### PR DESCRIPTION
This fixes two missing `"` in strings.po

Please merge https://github.com/Lunatixz/KODI_Addons/pull/89 first