### PR TITLE
Fixes issue where XML file could not be found

### DIFF
--- a/screensaver.videosaver/default.py
+++ b/screensaver.videosaver/default.py
@@ -264,7 +264,7 @@ class BackgroundWindow(xbmcgui.WindowXMLDialog):
         
 class Start():
     def __init__(self):
-        self.myBackground = BackgroundWindow('%s.background.xml'%ADDON_ID, ADDON_PATH, "default")
+        self.myBackground = BackgroundWindow('%s.background.xml'%ADDON_ID, ADDON_PATH, "Default")
         self.myBackground.doModal()
         del self.myBackground
         


### PR DESCRIPTION
Found an issue with some missing XML file. It turns out, the sub-directory is named `Default` as opposed to `default`.